### PR TITLE
removed condition of uploading e2e results because the results are go…

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,4 +54,3 @@ jobs:
         with:
           name: e2e-controller-k8s.log
           path: /tmp/e2e-controller.log
-        if: ${{ failure() }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Run e2e tests
         run: make test-e2e
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled) }}
-      - name: Upload e2e-controller logs
+      - name: Upload e2e-controller logs     # Codefresh changes
         uses: actions/upload-artifact@v2
         with:
           name: e2e-controller-k8s.log


### PR DESCRIPTION
…ing to be used in the case of success too

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).