### PR TITLE
fix: Handle minor version with '+' when determining ingress mode (#15…

### DIFF
--- a/utils/ingress/ingress.go
+++ b/utils/ingress/ingress.go
@@ -275,7 +275,11 @@ func DetermineIngressMode(apiVersion string, d discovery.ServerVersionInterface)
 	if err != nil {
 		return 0, err
 	}
-	minor, err := strconv.Atoi(ver.Minor)
+	verMinor := ver.Minor
+	if strings.HasSuffix(ver.Minor, "+") {
+		verMinor = ver.Minor[0 : len(ver.Minor)-1]
+	}
+	minor, err := strconv.Atoi(verMinor)
 	if err != nil {
 		return 0, err
 	}
@@ -286,5 +290,4 @@ func DetermineIngressMode(apiVersion string, d discovery.ServerVersionInterface)
 		return IngressModeNetworking, nil
 	}
 	return IngressModeExtensions, nil
-
 }

--- a/utils/ingress/ingress_test.go
+++ b/utils/ingress/ingress_test.go
@@ -330,6 +330,12 @@ func TestDetermineIngressMode(t *testing.T) {
 			expectedMode:  IngressModeExtensions,
 		},
 		{
+			name:          "will return networking mode if server minor version has '+' suffix, e.g. 1.19+",
+			apiVersion:    "",
+			faKeDiscovery: newFakeDiscovery("1", "19+", nil),
+			expectedMode:  IngressModeNetworking,
+		},
+		{
 			name:          "will return error if fails to retrieve server version",
 			apiVersion:    "",
 			faKeDiscovery: newFakeDiscovery("", "", errors.New("internal server error")),
@@ -355,6 +361,28 @@ func TestDetermineIngressMode(t *testing.T) {
 			expectedError: &strconv.NumError{
 				Func: "Atoi",
 				Num:  "wrong",
+				Err:  errors.New("invalid syntax"),
+			},
+		},
+		{
+			name:          "will return error if fails to parse minor version with '+' suffix, e.g. 1.wrong+",
+			apiVersion:    "",
+			faKeDiscovery: newFakeDiscovery("1", "wrong+", nil),
+			expectedMode:  0,
+			expectedError: &strconv.NumError{
+				Func: "Atoi",
+				Num:  "wrong",
+				Err:  errors.New("invalid syntax"),
+			},
+		},
+		{
+			name:          "will return error if fails to parse minor version with just '+'",
+			apiVersion:    "",
+			faKeDiscovery: newFakeDiscovery("1", "+", nil),
+			expectedMode:  0,
+			expectedError: &strconv.NumError{
+				Func: "Atoi",
+				Num:  "",
 				Err:  errors.New("invalid syntax"),
 			},
 		},


### PR DESCRIPTION
…29) (#1612)

Signed-off-by: Kiran Meduri <meduri@amazon.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [ ] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).